### PR TITLE
Refactor and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # MinecraftScript
-A script I made that installs minecraft and minecraft server globaly on linux systems
+A script I made that installs Minecraft and Minecraft server globally on Linux systems.
 ## dependencies
 
-  curl
-  java (for minecraft)
+  curl  
+  java (for Minecraft)  
 
-  to install the dependencies on ubuntu you can run
+  To install the dependencies on ubuntu you can run  
   `sudo apt-get install curl openjdk-8-jre`
 
 ## to install minecraft run
-`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s install`
+`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s install`  
 
-you might have to logout and login to reload the applications menu
+You might have to logout and login to reload the applications menu.
 
 ## to update minecraft run
-`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s update`
+`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s update`  
 
 ## to uninstall minecraft run
-`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s uninstall`
+`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s uninstall`  
 
 ## how to use once installed
-To run minecraft, look for it in your applications and it will be there, or via the terminal run
+To run Minecraft, look for it in your applications and it will be there, or via the terminal run  
 
 `minecraft`
 
-To start your minecraft server run this command in your server directory (by default, `/opt/`):
+To start your minecraft server run this command in your server directory (`/usr/bin/`)  
 
 `minecraft_server`
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
 # MinecraftScript
 A script I made that installs minecraft and minecraft server globaly on linux systems
-## dependencies  
+## dependencies
 
-  curl  
+  curl
   java (for minecraft)
 
-  to install the dependencies on ubuntu you can run  
+  to install the dependencies on ubuntu you can run
   `sudo apt-get install curl openjdk-8-jre`
 
 ## to install minecraft run
-`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s install`  
+`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s install`
 
 you might have to logout and login to reload the applications menu
 
 ## to update minecraft run
-`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s uninstall`  
+`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s update`
 
 ## to uninstall minecraft run
-`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s uninstall`  
+`curl -s https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraftInstaller.sh | bash -s uninstall`
 
 ## how to use once installed
-to run minecraft simply look for it in your applications and it will be there  
-or via the terminal run  
+To run minecraft, look for it in your applications and it will be there, or via the terminal run
+
 `minecraft`
 
-to start your minecraft server run this command in your server directory  
+To start your minecraft server run this command in your server directory (by default, `/opt/`):
+
 `minecraft_server`
 
-
-I have only tested on ubuntu but it should work on most linux distros that can normaly run minecraft
+I have only tested on ubuntu but it should work on most linux distros that can normally run Minecraft.

--- a/minecraft
+++ b/minecraft
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # java -Xmx1024M -Xms512M -cp /Minecraft*.jar net.minecraft.LauncherFrame
-export LD_LIBRARY_PATH="/usr/lib/jvm/java-7-oracle/jre/lib/i386/"
+# export LD_LIBRARY_PATH="/usr/lib/jvm/java-7-oracle/jre/lib/i386/"
+# NOTE commented out the above line, as I'm using openjdk-8-jre
 java -jar /opt/minecraft/Minecraft*.jar

--- a/minecraftInstaller.sh
+++ b/minecraftInstaller.sh
@@ -1,54 +1,74 @@
-#!/bin/bash
-tmpfile=/tmp/minecrafttempfile.tmp
-downloadurl="https://minecraft.net/en-us/download/server"
-loc=/opt/minecraft
+#!/usr/bin/env bash
+TEMPFILE=/tmp/minecrafttempfile.tmp
+DOWNLOAD_URL="https://minecraft.net/en-us/download/server"
+LOC=/opt/minecraft
+AWS_LAUNCHER=https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
+
+# assets
+GIT_HOME="https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master"
+MC_PNG="$GIT_HOME/minecraft.png"
+MC_DESKTOP="$GIT_HOME/Minecraft.desktop"
+MC_EXE="$GIT_HOME/minecraft"
+MC_SERVER="$GIT_HOME/minecraft_server"
+
+# logging
+Red='\033[37;41m'
 Purple='\033[0;35m'
 NC='\033[0m' # No Color
 
+PURPLE_ECHO() {
+    echo -e "${Purple}$1${NC}"
+}
+RED_ECHO() {
+    echo -e "${Red}$1${NC}"
+}
+
 if [ $1 != "update" ]; then
-  echo -e "${Purple}Grabbing minecraft download page...${NC}"
-  curl -s $downloadurl > $tmpfile
-  serverurl=`egrep -io 'https.*game\/(.*)\/server.jar' $tmpfile`
+    PURPLE_ECHO "Grabbing minecraft download page..."
+    curl -s $DOWNLOAD_URL > $TEMPFILE
+    SERVER_URL=`egrep -io 'https.*server.jar' $TEMPFILE`
 fi
 
 if [ $1 = "install" ]; then
-  echo -e "${Purple}Installing Minecraft${NC}"
-  sudo mkdir $loc
+    PURPLE_ECHO "Installing Minecraft"
+    sudo mkdir $LOC
 
-  echo -e "${Purple}Downloading server jar...${NC}"
-  sudo wget -q -O $loc/minecraft_server.jar $serverurl
+    PURPLE_ECHO "Downloading server jar..."
+    sudo wget -q -O $LOC/minecraft_server.jar $SERVER_URL
 
-  echo -e "${Purple}Downloading client jar...${NC}"
-  sudo wget -q -O $loc/Minecraft.jar https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
+    PURPLE_ECHO "Downloading client jar..."
+    sudo wget -q -O $LOC/Minecraft.jar $AWS_LAUNCHER
 
-  echo -e "${Purple}Downloading Minecraft.png${NC}"
-  sudo wget -q -O $loc/minecraft.png https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraft.png
+    PURPLE_ECHO "Downloading Minecraft.png..."
+    sudo wget -q -O $LOC/minecraft.png $MC_PNG
 
-  echo -e "${Purple}Downloading desktop file${NC}"
-  sudo wget -q -O /usr/share/applications/Minecraft.desktop https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/Minecraft.desktop
+    PURPLE_ECHO "Downloading desktop file..."
+    sudo wget -q -O /usr/share/applications/Minecraft.desktop $MC_DESKTOP
 
-  echo -e "${Purple}Downloading executables${NC}"
-  sudo wget -q -O /usr/bin/minecraft https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraft
-  sudo wget -q -O /usr/bin/minecraft_server https://raw.githubusercontent.com/keith-ferney/MinecraftScript/master/minecraft_server
-  sudo chmod +x /usr/bin/minecraft_server
-  sudo chmod +x /usr/bin/minecraft
-  echo -e "${Purple}Done${NC}"
+    PURPLE_ECHO "Downloading run scripts..."
+    sudo wget -q -O /usr/bin/minecraft $MC_EXE
+    sudo wget -q -O /usr/bin/minecraft_server $MC_SERVER
+    sudo chmod +x /usr/bin/minecraft_server
+    sudo chmod +x /usr/bin/minecraft
+    PURPLE_ECHO "Done"
+
 elif [ $1 = "uninstall" ]; then
-  echo -e "${Purple}Uninstalling Minecraft${NC}"
-  sudo rm -rf $loc
-  sudo rm -f /usr/share/applications/Minecraft.desktop
-  sudo rm -f /usr/bin/minecraft_server
-  sudo rm -f /usr/bin/minecraft
-  echo -e "${Purple}Done${NC}"
-elif [ $1 = "update" ]; then
-  if [ -e "$loc" ]; then
-    sudo rm -f $loc/*.jar
-    echo -e "${Purple}Downloading server jar...${NC}"
-    sudo wget -q -O $loc/minecraft_server.jar $serverurl
+    PURPLE_ECHO "Uninstalling Minecraft..."
+    sudo rm -rf $LOC
+    sudo rm -f /usr/share/applications/Minecraft.desktop
+    sudo rm -f /usr/bin/minecraft_server
+    sudo rm -f /usr/bin/minecraft
+    PURPLE_ECHO "Done"
 
-    echo -e "${Purple}Downloading client jar...${NC}"
-    sudo wget -q -O $loc/Minecraft.jar https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar
-  else
-    echo -e "${Purple}Can't update minecraft if it's not installed${NC}"
-  fi
+elif [ $1 = "update" ]; then
+    if [ -e "$LOC" ]; then
+        sudo rm -f $LOC/*.jar
+        PURPLE_ECHO "Downloading server jar..."
+        sudo wget -q -O $LOC/minecraft_server.jar $SERVER_URL
+
+        PURPLE_ECHO "Downloading client jar..."
+        sudo wget -q -O $LOC/Minecraft.jar $AWS_LAUNCHER
+    else
+        RED_ECHO "Can't update minecraft if it's not installed"
+    fi
 fi

--- a/minecraft_server
+++ b/minecraft_server
@@ -1,4 +1,5 @@
 #!/bin/bash
 # java -Xmx1024M -Xmx1024M -jar minecraft_server*.jar nogui
-export LD_LIBRARY_PATH="/usr/lib/jvm/java-7-oracle/jre/lib/i386/"
+# export LD_LIBRARY_PATH="/usr/lib/jvm/java-7-oracle/jre/lib/i386/"
+# NOTE commented out the above line, as I'm using openjdk-8-jre
 java -jar /opt/minecraft/minecraft_server*.jar


### PR DESCRIPTION
Main fix:

```diff
- serverurl=`egrep -io 'https.*game\/(.*)\/server.jar' $tmpfile`
+ SERVER_URL=`egrep -io 'https.*server.jar' $TEMPFILE`
```

I also refactored the script a little, to make it easier to replace the URLs if they change, and I took out the references to `LD_LIBRARY_PATH` from the `minecraft` and `minecraft_server` run scripts. 

Tested on Ubuntu 18.04 just now.